### PR TITLE
fix: footer extended indicators are placed horizontally, text with smaller size, improving the layout

### DIFF
--- a/mastodon/src/main/res/layout/display_item_extended_footer.xml
+++ b/mastodon/src/main/res/layout/display_item_extended_footer.xml
@@ -5,147 +5,163 @@
 	android:layout_width="match_parent"
 	android:layout_height="wrap_content">
 
-	<RelativeLayout
-		android:id="@+id/reblogs"
+	<LinearLayout
+		android:id="@+id/LinearLayout"
 		android:layout_width="match_parent"
-		android:layout_height="64dp"
-		android:paddingLeft="16dp"
-		android:paddingRight="16dp"
-		android:paddingTop="12dp"
-		android:paddingBottom="12dp"
-		android:background="?android:selectableItemBackground">
+		android:layout_height="wrap_content"
+		android:orientation="horizontal">
 
-		<ImageView
-			android:id="@+id/icon"
-			android:layout_width="24dp"
-			android:layout_height="24dp"
-			android:layout_alignParentStart="true"
-			android:layout_centerVertical="true"
-			android:src="@drawable/ic_fluent_arrow_repeat_all_24_regular"
-			android:tint="?android:textColorSecondary"
-			android:importantForAccessibility="no"/>
+		<RelativeLayout
+			android:id="@+id/reblogs"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:background="?android:selectableItemBackground"
+			android:paddingLeft="16dp"
+			android:paddingTop="12dp"
+			android:paddingRight="16dp"
+			android:paddingBottom="12dp">
 
-		<TextView
-			android:id="@+id/title"
+			<ImageView
+				android:id="@+id/icon"
+				android:layout_width="16dp"
+				android:layout_height="16dp"
+				android:layout_alignParentStart="true"
+				android:layout_centerVertical="true"
+				android:importantForAccessibility="no"
+				android:src="@drawable/ic_fluent_arrow_repeat_all_24_regular"
+				android:tint="?android:textColorSecondary" />
+
+			<TextView
+				android:id="@+id/title"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_marginStart="16dp"
+				android:layout_toEndOf="@id/icon"
+				android:minHeight="22dp"
+				android:singleLine="true"
+				android:text="@string/post_info_reblogs"
+				android:textAppearance="@style/m3_body_large"
+				android:textSize="14sp" />
+
+			<TextView
+				android:id="@+id/reblogs_count"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_below="@id/title"
+				android:layout_alignStart="@id/title"
+				android:singleLine="true"
+				android:textAppearance="@style/m3_body_medium"
+				android:textColor="?android:textColorSecondary"
+				android:textSize="12sp"
+				tools:text="123 456" />
+
+		</RelativeLayout>
+
+		<RelativeLayout
+			android:id="@+id/favorites"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:background="?android:selectableItemBackground"
+			android:paddingLeft="16dp"
+			android:paddingTop="12dp"
+			android:paddingRight="16dp"
+			android:paddingBottom="12dp">
+
+			<ImageView
+				android:id="@+id/icon"
+				android:layout_width="16dp"
+				android:layout_height="16dp"
+				android:layout_alignParentStart="true"
+				android:layout_centerVertical="true"
+				android:importantForAccessibility="no"
+				android:src="@drawable/ic_fluent_star_24_regular"
+				android:tint="?android:textColorSecondary" />
+
+			<TextView
+				android:id="@+id/title"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_marginStart="16dp"
+				android:layout_toEndOf="@id/icon"
+				android:minHeight="22dp"
+				android:singleLine="true"
+				android:text="@string/post_info_favorites"
+				android:textAppearance="@style/m3_body_large"
+				android:textSize="14sp" />
+
+			<TextView
+				android:id="@+id/favorites_count"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_below="@id/title"
+				android:layout_alignStart="@id/title"
+				android:singleLine="true"
+				android:textAppearance="@style/m3_body_medium"
+				android:textColor="?android:textColorSecondary"
+				android:textSize="12sp"
+				tools:text="123 456" />
+
+		</RelativeLayout>
+
+		<RelativeLayout
+			android:id="@+id/edit_history"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
-			android:layout_marginStart="32dp"
-			android:layout_toEndOf="@id/icon"
-			android:minHeight="22dp"
-			android:singleLine="true"
-			android:text="@string/post_info_reblogs"
-			android:textAppearance="@style/m3_body_large" />
+			android:background="?android:selectableItemBackground"
+			android:paddingLeft="16dp"
+			android:paddingTop="12dp"
+			android:paddingRight="16dp"
+			android:paddingBottom="12dp">
 
-		<TextView
-			android:id="@+id/reblogs_count"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:layout_below="@id/title"
-			android:layout_alignStart="@id/title"
-			android:singleLine="true"
-			android:textAppearance="@style/m3_body_medium"
-			android:textColor="?android:textColorSecondary"
-			tools:text="123 456"/>
+			<ImageView
+				android:id="@+id/icon"
+				android:layout_width="16dp"
+				android:layout_height="16dp"
+				android:layout_alignParentStart="true"
+				android:layout_centerVertical="true"
+				android:importantForAccessibility="no"
+				android:src="@drawable/ic_fluent_edit_24_regular"
+				android:tint="?android:textColorSecondary" />
 
-	</RelativeLayout>
+			<TextView
+				android:id="@+id/title"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_marginStart="16dp"
+				android:layout_toEndOf="@id/icon"
+				android:minHeight="22dp"
+				android:singleLine="true"
+				android:text="@string/edit_history"
+				android:textAppearance="@style/m3_body_large"
+				android:textSize="14sp" />
 
-	<RelativeLayout
-		android:id="@+id/favorites"
-		android:layout_width="match_parent"
-		android:layout_height="64dp"
-		android:paddingLeft="16dp"
-		android:paddingRight="16dp"
-		android:paddingTop="12dp"
-		android:paddingBottom="12dp"
-		android:background="?android:selectableItemBackground">
+			<TextView
+				android:id="@+id/last_edited"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_below="@id/title"
+				android:layout_alignStart="@id/title"
+				android:singleLine="false"
+				android:textAppearance="@style/m3_body_medium"
+				android:textColor="?android:textColorSecondary"
+				android:textSize="11sp"
+				tools:text="123 456" />
 
-		<ImageView
-			android:id="@+id/icon"
-			android:layout_width="24dp"
-			android:layout_height="24dp"
-			android:layout_alignParentStart="true"
-			android:layout_centerVertical="true"
-			android:src="@drawable/ic_fluent_star_24_regular"
-			android:tint="?android:textColorSecondary"
-			android:importantForAccessibility="no"/>
-
-		<TextView
-			android:id="@+id/title"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:layout_marginStart="32dp"
-			android:layout_toEndOf="@id/icon"
-			android:minHeight="22dp"
-			android:singleLine="true"
-			android:text="@string/post_info_favorites"
-			android:textAppearance="@style/m3_body_large" />
-
-		<TextView
-			android:id="@+id/favorites_count"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:layout_below="@id/title"
-			android:layout_alignStart="@id/title"
-			android:singleLine="true"
-			android:textAppearance="@style/m3_body_medium"
-			android:textColor="?android:textColorSecondary"
-			tools:text="123 456"/>
-
-	</RelativeLayout>
-
-	<RelativeLayout
-		android:id="@+id/edit_history"
-		android:layout_width="match_parent"
-		android:layout_height="64dp"
-		android:paddingLeft="16dp"
-		android:paddingRight="16dp"
-		android:paddingTop="12dp"
-		android:paddingBottom="12dp"
-		android:background="?android:selectableItemBackground">
-
-		<ImageView
-			android:id="@+id/icon"
-			android:layout_width="24dp"
-			android:layout_height="24dp"
-			android:layout_alignParentStart="true"
-			android:layout_centerVertical="true"
-			android:src="@drawable/ic_fluent_edit_24_regular"
-			android:tint="?android:textColorSecondary"
-			android:importantForAccessibility="no"/>
-
-		<TextView
-			android:id="@+id/title"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:layout_marginStart="32dp"
-			android:layout_toEndOf="@id/icon"
-			android:minHeight="22dp"
-			android:singleLine="true"
-			android:text="@string/edit_history"
-			android:textAppearance="@style/m3_body_large" />
-
-		<TextView
-			android:id="@+id/last_edited"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:layout_below="@id/title"
-			android:layout_alignStart="@id/title"
-			android:singleLine="true"
-			android:textAppearance="@style/m3_body_medium"
-			android:textColor="?android:textColorSecondary"
-			tools:text="123 456"/>
-
-	</RelativeLayout>
+		</RelativeLayout>
+	</LinearLayout>
 
 	<TextView
 		android:id="@+id/timestamp"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
-		android:layout_margin="16dp"
-		android:minHeight="20dp"
+		android:layout_marginLeft="16dp"
+		android:layout_marginTop="16dp"
+		android:layout_marginRight="16dp"
+		android:layout_marginBottom="8dp"
 		android:gravity="center_vertical"
-		android:textSize="14sp"
+		android:minHeight="20dp"
 		android:textColor="?android:textColorSecondary"
-		tools:text="Dec 12, 2021, 12:42 PM via Mastodon for Android"/>
+		android:textSize="14sp"
+		tools:text="Dec 12, 2021, 12:42 PM via Mastodon for Android" />
 
 </LinearLayout>

--- a/mastodon/src/main/res/layout/display_item_extended_footer.xml
+++ b/mastodon/src/main/res/layout/display_item_extended_footer.xml
@@ -144,7 +144,7 @@
 				android:singleLine="false"
 				android:textAppearance="@style/m3_body_medium"
 				android:textColor="?android:textColorSecondary"
-				android:textSize="11sp"
+				android:textSize="10sp"
 				tools:text="123 456" />
 
 		</RelativeLayout>
@@ -155,7 +155,7 @@
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:layout_marginLeft="16dp"
-		android:layout_marginTop="16dp"
+		android:layout_marginTop="8dp"
 		android:layout_marginRight="16dp"
 		android:layout_marginBottom="8dp"
 		android:gravity="center_vertical"


### PR DESCRIPTION
Hi, I modified the layout of the footer item each time a new post is opened. It is an improvement in my opinion, since the layout comming from upstream occupies a lot of space and distracts from the main content. Here is a picture for comparison: 
![PR-changeOfFooterLayout](https://user-images.githubusercontent.com/749275/201050403-3313f96c-e9f8-4772-8a18-5ec8cb067051.png)

Let me know what you think, cheers

